### PR TITLE
Fix typo runtime-configuration.md

### DIFF
--- a/content/docs/runtime-configuration.md
+++ b/content/docs/runtime-configuration.md
@@ -81,7 +81,7 @@ LOG_LEVEL=debug
 DB_CONNECTION=mysql
 DB_HOST={{ .runtime.db.host }}
 DB_PORT=3306
-DB_DATABASE={{ .runtime.db.database }}
+DB_DATABASE={{ .runtime.db.name }}
 DB_USERNAME={{ .runtime.db.user }}
 DB_PASSWORD={{ .runtime.db.password }}
 


### PR DESCRIPTION
Fixing typo
- 84 DB_DATABASE={{ .runtime.db.database }}
+ 84 DB_DATABASE={{ .runtime.db.name }}